### PR TITLE
Board cleanup, Splash screen fix

### DIFF
--- a/JailbreakPong/app/src/main/java/com/kaze/jailbreakpong/Board.java
+++ b/JailbreakPong/app/src/main/java/com/kaze/jailbreakpong/Board.java
@@ -18,6 +18,16 @@ public class Board {
 
     private Board() {}
 
+    public class Boundaries {
+        float boardTop, playerTop, opponentTop, boardBottom;
+        public Boundaries(float boardTop, float opponentTop, float playerTop, float boardBottom) {
+            this.boardTop = boardTop;
+            this.opponentTop = opponentTop;
+            this.playerTop = playerTop;
+            this.boardBottom = boardBottom;
+        }
+    }
+
     // during runtime, MainActivity tells us the screen dimensions in pixels, and the dpi
     public void init(Context context) {
         // get current phone screen size
@@ -64,20 +74,14 @@ public class Board {
         return gridItemSize;
     }
 
-    public float getBoardTop() {
-        return verticalOffset;
-    }
+    public Boundaries getBoardBoundaries() {
+        float boardTop = verticalOffset;
+        float opponentTop = playerRows * gridItemSize + verticalOffset;
+        float playerTop = (playerRows + neutralRows) * gridItemSize + verticalOffset;
+        float boardBottom = numRows * gridItemSize + verticalOffset;
+        Boundaries boundaries = new Boundaries(boardTop, opponentTop, playerTop, boardBottom);
 
-    public float getOpponentTop() {
-        return playerRows * gridItemSize + verticalOffset;
-    }
-
-    public float getPlayerTop() {
-        return (playerRows + neutralRows) * gridItemSize + verticalOffset;
-    }
-
-    public float getBoardBottom() {
-        return numRows * gridItemSize + verticalOffset;
+        return boundaries;
     }
 
     public ArrayList<ArrayList<GridItem>> getGrid() {

--- a/JailbreakPong/app/src/main/java/com/kaze/jailbreakpong/BoardView.java
+++ b/JailbreakPong/app/src/main/java/com/kaze/jailbreakpong/BoardView.java
@@ -22,16 +22,16 @@ public class BoardView extends View {
 
     public BoardView(Context context){
         super(context);
-        Board board = Board.getInstance();
         mPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
 
         // get board boundaries
-        boardTop = board.getBoardTop();
-        opponentTop = board.getOpponentTop();
-        playerTop = board.getPlayerTop();
-        boardBottom = board.getBoardBottom();
-        gridItemSize = board.getGridItemSize();
-        sectionWidth = gridItemSize * board.getNumColumns();
+        Board.Boundaries boundaries = Helper.getBoardBoundaries();
+        boardTop = boundaries.boardTop;
+        opponentTop = boundaries.opponentTop;
+        playerTop = boundaries.playerTop;
+        boardBottom = boundaries.boardBottom;
+        gridItemSize = Helper.getGridItemSize();
+        sectionWidth = gridItemSize * Helper.getNumColumns();
 
         // initialize colors
         paleBlue = ResourcesCompat.getColor(getResources(), R.color.paleBlue, null);

--- a/JailbreakPong/app/src/main/java/com/kaze/jailbreakpong/Brick.java
+++ b/JailbreakPong/app/src/main/java/com/kaze/jailbreakpong/Brick.java
@@ -25,7 +25,7 @@ public abstract class Brick extends GridItem{
 
         isVisible = true;
         this.hp = hp;
-        this.gapSize = (int) Board.getInstance().getBoardTop() * 2;
+        this.gapSize = (int) Helper.getBoardBoundaries().boardTop * 2;
 
         int padding = 1;
 

--- a/JailbreakPong/app/src/main/java/com/kaze/jailbreakpong/Brick.java
+++ b/JailbreakPong/app/src/main/java/com/kaze/jailbreakpong/Brick.java
@@ -25,7 +25,7 @@ public abstract class Brick extends GridItem{
 
         isVisible = true;
         this.hp = hp;
-        this.gapSize = (int) Board.getInstance().getGapSize();
+        this.gapSize = (int) Board.getInstance().getBoardTop() * 2;
 
         int padding = 1;
 

--- a/JailbreakPong/app/src/main/java/com/kaze/jailbreakpong/GridItem.java
+++ b/JailbreakPong/app/src/main/java/com/kaze/jailbreakpong/GridItem.java
@@ -1,12 +1,8 @@
 package com.kaze.jailbreakpong;
 
 import android.content.Context;
-import android.graphics.LinearGradient;
-import android.graphics.Rect;
-import android.graphics.Shader;
 import android.view.View;
 import android.graphics.Canvas;
-import android.graphics.Paint;
 
 import java.util.ArrayList;
 

--- a/JailbreakPong/app/src/main/java/com/kaze/jailbreakpong/Helper.java
+++ b/JailbreakPong/app/src/main/java/com/kaze/jailbreakpong/Helper.java
@@ -71,4 +71,26 @@ public class Helper {
         }
         return 0;
     }
+
+    // returns an array of board boundaries in pixels (y-axis)
+    // {boardTop, opponentTop, playerTop, boardBottom}
+    public static Board.Boundaries getBoardBoundaries(){
+        Board board = Board.getInstance();
+        return board.getBoardBoundaries();
+    }
+
+    public static float getGridItemSize() {
+        Board board = Board.getInstance();
+        return board.getGridItemSize();
+    }
+
+    public static float getNumColumns() {
+        Board board = Board.getInstance();
+        return board.getNumColumns();
+    }
+
+    public static float getNumRowss() {
+        Board board = Board.getInstance();
+        return board.getNumRows();
+    }
 }

--- a/JailbreakPong/app/src/main/java/com/kaze/jailbreakpong/Helper.java
+++ b/JailbreakPong/app/src/main/java/com/kaze/jailbreakpong/Helper.java
@@ -1,6 +1,7 @@
 package com.kaze.jailbreakpong;
 
 import android.content.Context;
+import android.content.res.Resources;
 import android.content.res.TypedArray;
 import android.nfc.Tag;
 import android.util.DisplayMetrics;
@@ -60,5 +61,14 @@ public class Helper {
 
         Log.d(DEBUG, "getStatusBarHeight: statusBarHeight: " + statusBarHeight);
         return statusBarHeight;
+    }
+
+    public static int getNavbarHeight(Context context) {
+        Resources resources = context.getResources();
+        int resourceId = resources.getIdentifier("navigation_bar_height", "dimen", "android");
+        if (resourceId > 0) {
+            return resources.getDimensionPixelSize(resourceId);
+        }
+        return 0;
     }
 }

--- a/JailbreakPong/app/src/main/java/com/kaze/jailbreakpong/MainActivity.java
+++ b/JailbreakPong/app/src/main/java/com/kaze/jailbreakpong/MainActivity.java
@@ -3,34 +3,10 @@ package com.kaze.jailbreakpong;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.content.res.ResourcesCompat;
 
-import android.content.res.Resources;
-import android.graphics.Canvas;
-import android.graphics.LinearGradient;
-import android.graphics.PixelFormat;
-import android.graphics.Rect;
-import android.graphics.Shader;
 import android.os.Bundle;
-import android.view.SurfaceHolder;
-import android.view.SurfaceView;
 import android.view.View;
-import android.util.DisplayMetrics;
-import android.view.Display;
-import android.graphics.Paint;
 import android.view.WindowManager;
 import android.widget.FrameLayout;
-import android.animation.Animator;
-import android.animation.AnimatorListenerAdapter;
-import android.animation.PropertyValuesHolder;
-import android.animation.ValueAnimator;
-import android.content.Context;
-import android.content.res.Resources;
-import android.content.res.TypedArray;
-import android.graphics.Point;
-import android.os.Bundle;
-import android.util.DisplayMetrics;
-import android.widget.LinearLayout;
-
-import static java.lang.Math.round;
 
 public class MainActivity extends AppCompatActivity {
 
@@ -41,16 +17,8 @@ public class MainActivity extends AppCompatActivity {
         getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
         hideSystemUI();
 
-        Display display = getWindowManager().getDefaultDisplay();
-        DisplayMetrics displayMetrics = new DisplayMetrics();
-        display.getMetrics(displayMetrics);
-
-        float density = getResources().getDisplayMetrics().density;
-        final float pxHeight = displayMetrics.heightPixels + getNavbarHeight();
-        final float pxWidth = displayMetrics.widthPixels;
-
         final Board board = Board.getInstance();
-        board.init(getApplicationContext(), pxWidth, pxHeight, density);
+        board.init(getApplicationContext());
         //drawBoardBackground(board);
         BoardView boardView = new BoardView(getApplicationContext());
         FrameLayout fl = (FrameLayout) findViewById(R.id.FrameLayout);
@@ -63,12 +31,18 @@ public class MainActivity extends AppCompatActivity {
         board.initBoard(fl, getApplicationContext(), playerTileColorLight, playerTileColorDark, opponentTileColorLight, opponentTileColorDark);
         //drawGridItems(board);
 
-      // create a ball
-      Ball ball = Helper.initBall(this, 0, board.getGapBtm(), 100, 1f);
-      ball.addAnimators(board.getGapBtm(), board.getPlayerBtm());
-
-      // add to the layout
-      FrameLayout layout = findViewById(R.id.FrameLayout);
+        // Code to add the ball to the layout. Need to 'merge' in future commits
+//      float x = (float) metrics.widthPixels / 2;
+//      float y = (float) metrics.heightPixels / 2;
+//
+//      // create a ball
+      Ball ball = Helper.initBall(this, 0, board.getBoardTop(), 100, 0.5f);
+//
+      ball.addAnimators(board.getBoardTop(), board.getBoardBottom());
+      // need y endpoints
+//
+//      // add to the layout
+      FrameLayout layout = (FrameLayout) findViewById(R.id.FrameLayout);
       layout.addView(ball);
     }
 
@@ -76,45 +50,6 @@ public class MainActivity extends AppCompatActivity {
     public void onResume() {
         super.onResume();
     }
-
-
-//    public void drawGridItems(final Board board) {
-//        final SurfaceView gridItemBoard = findViewById(R.id.boardBackground);
-//        gridItemBoard.setZOrderOnTop(true);
-//        gridItemBoard.getHolder().addCallback(new SurfaceHolder.Callback() {
-//            @Override
-//            public void surfaceCreated(SurfaceHolder surfaceHolder) {
-//                surfaceHolder.setFormat(PixelFormat.RGBA_8888);
-//                Canvas canvas = surfaceHolder.lockCanvas();
-//                Paint mPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
-//
-//                int nRows = board.getNumRows();
-//                int nCols = board.getNumColumns();
-//                int gapBtm = (int) board.getGapBtm();
-//
-//                // at start adjust canvas down to account for gap
-//                canvas.translate(0, gapBtm);
-//
-//                Drawing drawing = new Drawing(board.getNumRows(), board.getNumColumns());
-//                drawing.initDraw(board.getGrid(), canvas);
-//
-//                surfaceHolder.unlockCanvasAndPost(canvas);
-//                // at very end undo canvas translation
-//                canvas.save();
-//                canvas.restore();
-//            }
-//
-//            @Override
-//            public void surfaceChanged(SurfaceHolder surfaceHolder, int i, int i1, int i2) {
-//
-//            }
-//
-//            @Override
-//            public void surfaceDestroyed(SurfaceHolder surfaceHolder) {
-//
-//            }
-//        });
-//    }
 
     public void onWindowFocusChanged(boolean hasFocus) {
         super.onWindowFocusChanged(hasFocus);
@@ -136,14 +71,5 @@ public class MainActivity extends AppCompatActivity {
                         | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION // hide nav bar
                         | View.SYSTEM_UI_FLAG_FULLSCREEN // hide status bar
                         | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
-    }
-
-    public int getNavbarHeight() {
-        Resources resources = getResources();
-        int resourceId = resources.getIdentifier("navigation_bar_height", "dimen", "android");
-        if (resourceId > 0) {
-            return resources.getDimensionPixelSize(resourceId);
-        }
-        return 0;
     }
 }

--- a/JailbreakPong/app/src/main/java/com/kaze/jailbreakpong/MainActivity.java
+++ b/JailbreakPong/app/src/main/java/com/kaze/jailbreakpong/MainActivity.java
@@ -19,7 +19,8 @@ public class MainActivity extends AppCompatActivity {
 
         final Board board = Board.getInstance();
         board.init(getApplicationContext());
-        //drawBoardBackground(board);
+        Board.Boundaries boardBoundaries = Helper.getBoardBoundaries();
+
         BoardView boardView = new BoardView(getApplicationContext());
         FrameLayout fl = (FrameLayout) findViewById(R.id.FrameLayout);
         fl.addView(boardView);
@@ -29,16 +30,11 @@ public class MainActivity extends AppCompatActivity {
         int opponentTileColorLight = ResourcesCompat.getColor(getResources(), R.color.gradientYellowLight, null);
         int opponentTileColorDark = ResourcesCompat.getColor(getResources(), R.color.gradientYellowDark, null);
         board.initBoard(fl, getApplicationContext(), playerTileColorLight, playerTileColorDark, opponentTileColorLight, opponentTileColorDark);
-        //drawGridItems(board);
 
-        // Code to add the ball to the layout. Need to 'merge' in future commits
-//      float x = (float) metrics.widthPixels / 2;
-//      float y = (float) metrics.heightPixels / 2;
-//
 //      // create a ball
-      Ball ball = Helper.initBall(this, 0, board.getBoardTop(), 100, 0.5f);
+      Ball ball = Helper.initBall(this, 0, boardBoundaries.boardTop, 100, 0.5f);
 //
-      ball.addAnimators(board.getBoardTop(), board.getBoardBottom());
+      ball.addAnimators(boardBoundaries.boardTop, boardBoundaries.boardBottom);
       // need y endpoints
 //
 //      // add to the layout

--- a/JailbreakPong/app/src/main/java/com/kaze/jailbreakpong/SplashActivity.java
+++ b/JailbreakPong/app/src/main/java/com/kaze/jailbreakpong/SplashActivity.java
@@ -10,7 +10,7 @@ public class SplashActivity extends Activity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.spalsh_screen);
+        setContentView(R.layout.splash_screen);
 
         handler=new Handler();
         handler.postDelayed(new Runnable() {

--- a/JailbreakPong/app/src/main/res/drawable/ic_splashbackground.xml
+++ b/JailbreakPong/app/src/main/res/drawable/ic_splashbackground.xml
@@ -1,0 +1,21 @@
+<vector android:height="24dp" android:viewportHeight="640"
+    android:viewportWidth="360" android:width="24dp"
+    xmlns:aapt="http://schemas.android.com/aapt" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:pathData="M0,0h360v640h-360z">
+        <aapt:attr name="android:fillColor">
+            <gradient android:endX="360" android:endY="640"
+                android:startX="180" android:startY="-6.4" android:type="linear">
+                <item android:color="#FF009DFF" android:offset="0"/>
+                <item android:color="#FF009DFF" android:offset="0.325"/>
+                <item android:color="#FF27B3FA" android:offset="0.399"/>
+                <item android:color="#FF4ECAF5" android:offset="0.488"/>
+                <item android:color="#FF6EDDF1" android:offset="0.58"/>
+                <item android:color="#FF87ECEE" android:offset="0.675"/>
+                <item android:color="#FF99F6EC" android:offset="0.773"/>
+                <item android:color="#FFA3FCEB" android:offset="0.878"/>
+                <item android:color="#FFA7FFEB" android:offset="0.961"/>
+                <item android:color="#FFA7FFEB" android:offset="1"/>
+            </gradient>
+        </aapt:attr>
+    </path>
+</vector>

--- a/JailbreakPong/app/src/main/res/drawable/ic_splashlogo.xml
+++ b/JailbreakPong/app/src/main/res/drawable/ic_splashlogo.xml
@@ -1,0 +1,42 @@
+<vector android:height="24dp" android:viewportHeight="108"
+    android:viewportWidth="108" android:width="24dp"
+    xmlns:aapt="http://schemas.android.com/aapt" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:pathData="M100,0L0,0L0,108L108,108L108,0ZM8,100L8,8h8.67v92ZM24.67,100L24.67,8h8.66v92ZM41.33,100L41.33,8L50,8v92ZM58,100L58,8h8.67v92ZM74.67,100L74.67,8h8.66v92ZM100,100L91.33,100L91.33,8L100,8Z">
+        <aapt:attr name="android:fillColor">
+            <gradient android:endX="54" android:endY="108"
+                android:startX="54" android:startY="0" android:type="linear">
+                <item android:color="#FFE6E6E6" android:offset="0"/>
+                <item android:color="#FF717473" android:offset="1"/>
+            </gradient>
+        </aapt:attr>
+    </path>
+    <path android:pathData="M34.9,88.4A27.49,27.49 0,0 1,39.2 76,32.29 32.29,0 0,1 56.9,62.9l3.8,-1.4L46.5,45A57.59,57.59 0,0 0,36.1 65.3a53,53 0,0 0,-1.2 23.1Z">
+        <aapt:attr name="android:fillColor">
+            <gradient android:endX="130.11746" android:endY="-2599.4055"
+                android:startX="98.48522" android:startY="-2630.393" android:type="linear">
+                <item android:color="#0081D4FA" android:offset="0"/>
+                <item android:color="#0986D6FA" android:offset="0.01"/>
+                <item android:color="#389CDDFB" android:offset="0.05"/>
+                <item android:color="#62B2E5FC" android:offset="0.09"/>
+                <item android:color="#86C4EBFD" android:offset="0.14"/>
+                <item android:color="#A8D4F0FD" android:offset="0.2"/>
+                <item android:color="#C4E2F5FE" android:offset="0.25"/>
+                <item android:color="#D9EDF9FE" android:offset="0.32"/>
+                <item android:color="#EBF5FCFF" android:offset="0.4"/>
+                <item android:color="#F7FBFEFF" android:offset="0.49"/>
+                <item android:color="#FBFEFFFF" android:offset="0.63"/>
+                <item android:color="#FFFFFFFF" android:offset="1"/>
+            </gradient>
+        </aapt:attr>
+    </path>
+    <path android:pathData="M53.4,53.9m-11.3,0a11.3,11.3 0,1 1,22.6 0a11.3,11.3 0,1 1,-22.6 0">
+        <aapt:attr name="android:fillColor">
+            <gradient android:endX="53.4" android:endY="65.38898"
+                android:startX="53.4" android:startY="42.379" android:type="linear">
+                <item android:color="#FFE65100" android:offset="0"/>
+                <item android:color="#FB90996A" android:offset="0.63"/>
+                <item android:color="#F718FFFF" android:offset="1"/>
+            </gradient>
+        </aapt:attr>
+    </path>
+</vector>

--- a/JailbreakPong/app/src/main/res/layout/spalsh_screen.xml
+++ b/JailbreakPong/app/src/main/res/layout/spalsh_screen.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:gravity="center"
-    android:background="@drawable/splash_screen">
-
-</RelativeLayout>

--- a/JailbreakPong/app/src/main/res/layout/splash_screen.xml
+++ b/JailbreakPong/app/src/main/res/layout/splash_screen.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@drawable/ic_splashbackground"
+    android:orientation="vertical">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="128dp"
+        android:orientation="vertical">
+        <ImageView
+            android:id="@+id/imageView"
+            android:layout_width="match_parent"
+            android:layout_height="112dp"
+            android:src="@drawable/ic_splashlogo"/>
+
+        <TextView
+            android:id="@+id/textView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:paddingVertical="16dp"
+            android:text="Jailbreak Pong"
+            android:textColor="@color/white"
+            android:textSize="36sp" />
+    </LinearLayout>
+</RelativeLayout>


### PR DESCRIPTION
- Simplify logic for board
- Reduce number of parameters
- Increase onDraw efficiency for boardView
- Made board boundary/dimension functions available in Helper class so other objects don't need a copy of the Board
- Redid splash screen layout so that it's not a picture of the mockup (doesn't scale on screens of different sizes).