### PR TITLE
Add pause to helper to enforce pause instead of toggle pause/play

### DIFF
--- a/JailbreakPong/app/src/main/java/com/kaze/jailbreakpong/Helper.java
+++ b/JailbreakPong/app/src/main/java/com/kaze/jailbreakpong/Helper.java
@@ -140,6 +140,13 @@ public class Helper {
         board.togglePlayPause();
     }
 
+    // to be used by screen capture, must pause game
+    // and do not toggle play if game is already paused
+    public static void setPause() {
+        Board board = Board.getInstance();
+        board.pause();
+    }
+
     public static void restart() {
         Board board = Board.getInstance();
         board.restart();


### PR DESCRIPTION
Add set pause helper function to ensure we pause, not toggle play/pause for asking permissions, etc.
case:
- user pauses game
- user starts recording
- recording toggles pause play
- game plays - not good

This will help fix the above case.